### PR TITLE
record session_started

### DIFF
--- a/lib/encrypted_cookie_store.rb
+++ b/lib/encrypted_cookie_store.rb
@@ -28,7 +28,7 @@ class EncryptedCookieStore < ActionController::Session::CookieStore
     old_session_data, raw_old_session_data, old_timestamp = all_unpacked_cookie_data(env)
     # make sure we have a deep copy
     old_session_data = Marshal.load(raw_old_session_data) if raw_old_session_data
-    env['encrypted_cookie_store.session_started'] ||= session_started(old_timestamp, env)
+    env['encrypted_cookie_store.session_refreshed_at'] ||= session_refreshed_at(old_timestamp, env)
 
     status, headers, body = @app.call(env)
 
@@ -134,7 +134,7 @@ private
     all_unpacked_cookie_data(env).first
   end
 
-  def session_started(timestamp, env)
+  def session_refreshed_at(timestamp, env)
     expire_after = env[ENV_SESSION_OPTIONS_KEY][:expire_after] || @options[:expire_after]
     Time.at(timestamp).utc - expire_after if timestamp && expire_after
   end


### PR DESCRIPTION
allows the application to check when the session was (approximately, assuming the expire_after setting hasn't changed since the session was last set) started
