### PR TITLE
fix calculation of session_refreshed_at timestamp

### DIFF
--- a/lib/encrypted_cookie_store.rb
+++ b/lib/encrypted_cookie_store.rb
@@ -28,7 +28,7 @@ class EncryptedCookieStore < ActionController::Session::CookieStore
     old_session_data, raw_old_session_data, old_timestamp = all_unpacked_cookie_data(env)
     # make sure we have a deep copy
     old_session_data = Marshal.load(raw_old_session_data) if raw_old_session_data
-    env['encrypted_cookie_store.session_refreshed_at'] ||= session_refreshed_at(old_timestamp, env)
+    env['encrypted_cookie_store.session_refreshed_at'] ||= session_refreshed_at(old_timestamp)
 
     status, headers, body = @app.call(env)
 
@@ -134,9 +134,8 @@ private
     all_unpacked_cookie_data(env).first
   end
 
-  def session_refreshed_at(timestamp, env)
-    expire_after = env[ENV_SESSION_OPTIONS_KEY][:expire_after] || @options[:expire_after]
-    Time.at(timestamp).utc - expire_after if timestamp && expire_after
+  def session_refreshed_at(timestamp)
+    Time.at(timestamp).utc if timestamp
   end
 
   # To prevent users from using an insecure encryption key like "Password" we make sure that the


### PR DESCRIPTION
the timestamp stored in the encrypted cookie already represents the
"session_refreshed_at" value. in 1.0.3 we incorrectly interpreted it as
a "expires_at" value, as if it already included the expire_after value
