### PR TITLE
fix encryption for Ruby 2.4

### DIFF
--- a/spec/encrypted_cookie_store_spec.rb
+++ b/spec/encrypted_cookie_store_spec.rb
@@ -34,6 +34,10 @@ describe EncryptedCookieStore do
     ActionDispatch::Cookies.new(store).send(:call, env)
   end
 
+  it "errors on too short of encryption key" do
+    expect { create_store(secret: "0123456789") }.to raise_error(ArgumentError)
+  end
+
   specify "marshalling and unmarshalling data works" do
     data   = create_store.send(:marshal, OBJECT)
     object = create_store.send(:unmarshal, data)


### PR DESCRIPTION
Ruby 2.4 validates the encryption key length is exactly the
correct size, instead of just long enough. but be careful, because
we still use the secret for the HMAC, which can take a key of
any length. so only truncate what goes to encryption, not what
goes to HMAC