### PR TITLE
fix refreshing the session on every request

### DIFF
--- a/lib/encrypted_cookie_store.rb
+++ b/lib/encrypted_cookie_store.rb
@@ -97,7 +97,7 @@ module ActionDispatch
               data.stringify_keys!
             end
             data ||= {}
-            set_header(req, 'encrypted_cookie_store.original_cookie', data.deep_dup.except(:timestamp))
+            set_header(req, 'encrypted_cookie_store.original_cookie', data.deep_dup.except('timestamp'))
             data
           end
           set_header(req, k, v)
@@ -108,7 +108,7 @@ module ActionDispatch
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{write_session}(req, sid, session_data, options)
           session_data = super
-          session_data.delete(:timestamp)
+          session_data.delete('timestamp')
           marshal(session_data, options)
         end
       RUBY
@@ -124,7 +124,7 @@ module ActionDispatch
       end
 
       def session_changed?(req, session)
-        (session || {}).to_hash.stringify_keys.except(:timestamp) != (get_header(req, 'encrypted_cookie_store.original_cookie') || {})
+        (session || {}).to_hash.stringify_keys.except('timestamp') != (get_header(req, 'encrypted_cookie_store.original_cookie') || {})
       end
 
       def refresh_session?(req, options)
@@ -183,7 +183,7 @@ module ActionDispatch
             @logger.error("Could not unmarshal session_data: #{session_data.inspect}") if @logger
           end
 
-          loaded_data[:timestamp] = timestamp if loaded_data && timestamp
+          loaded_data['timestamp'] = timestamp if loaded_data && timestamp
           loaded_data
         else
           nil

--- a/spec/encrypted_cookie_store_spec.rb
+++ b/spec/encrypted_cookie_store_spec.rb
@@ -82,7 +82,7 @@ describe EncryptedCookieStore do
     store = create_store
     data = store.send(:marshal, OBJECT, :expire_after => 1.day)
     result = store.send(:unmarshal, data, :expire_after => 1.day)
-    timestamp = result.delete(:timestamp)
+    timestamp = result.delete('timestamp')
     expect(timestamp).not_to be_nil
     expect(result).to eq(OBJECT)
   end
@@ -134,14 +134,16 @@ describe EncryptedCookieStore do
   it "should not refresh the cookie if the session didn't change" do
     parent = MockApplication.new do |env|
       env[SESSION_KEY][:hello] = 'world'
+      env[SESSION_KEY]['timestamp'] -= 1 if env[SESSION_KEY]['timestamp']
       [200, {}, []]
     end
-    store = create_store(:app => parent)
+    store = create_store(:app => parent, :expire_after => 1.day)
 
     result = write_headers(store)
     expect(result[1]['Set-Cookie']).not_to be_nil
 
     env = { 'HTTP_COOKIE' => result[1]['Set-Cookie'] }
+
     result = write_headers(store, env)
     expect(result[1]).to eq({})
   end


### PR DESCRIPTION
keys are strings; don't use a symbol for the timestamp key